### PR TITLE
Implementing policy-based ApiKey authorization

### DIFF
--- a/test/AspNet.Security.ApiKey.Providers.Web/Controllers/ValuesController.cs
+++ b/test/AspNet.Security.ApiKey.Providers.Web/Controllers/ValuesController.cs
@@ -7,7 +7,7 @@ namespace AspNet.Security.ApiKey.Providers.Web.Controllers
     public class ValuesController : Controller
     {
         [HttpGet, Route("api/authenticated/values")]
-        [Authorize]
+        [Authorize(Policy="ApiKeyPolicy")]
         public IEnumerable<string> Auth() => new[] { "value1", "value2" };
 
         [HttpGet, Route("api/anonymous/values")]

--- a/test/AspNet.Security.ApiKey.Providers.Web/Policies/ApiKeyRequirement.cs
+++ b/test/AspNet.Security.ApiKey.Providers.Web/Policies/ApiKeyRequirement.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+
+namespace AspNet.Security.ApiKey.Providers.Web.Policies
+{
+
+    // https://blog.dangl.me/archive/securing-aspnet-core-controllers-with-a-policy-and-api-keys/
+
+    /// <summary>
+    /// The APIKey requirement
+    /// </summary>
+    public class ApiKeyRequirement : IAuthorizationRequirement
+    {
+        /// <summary>The ApiKey to check</summary>
+        public string ApiKey { get; set;}
+
+        /// <summary>
+        /// Construct an API key requirement
+        /// </summary>
+        /// <param name="apiKey"></param>
+        public ApiKeyRequirement(string apiKey)
+        {
+            ApiKey = apiKey;
+        }
+    }
+}

--- a/test/AspNet.Security.ApiKey.Providers.Web/Policies/ApiKeyRequirementHandler.cs
+++ b/test/AspNet.Security.ApiKey.Providers.Web/Policies/ApiKeyRequirementHandler.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace AspNet.Security.ApiKey.Providers.Web.Policies
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ApiKeyRequirementHandler : AuthorizationHandler<ApiKeyRequirement>
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="requirement"></param>
+        /// <returns></returns>
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ApiKeyRequirement requirement)
+        {
+            if (context.Resource is AuthorizationFilterContext authorizationFilterContext)
+            {
+                if (!context.User.HasClaim(c => c.Type == "ApiKey"))
+                {
+                    return Task.CompletedTask;
+                }
+
+                var principalApiKey = context.User.FindFirst(c => c.Type == "ApiKey").Value;
+                if (principalApiKey == requirement.ApiKey)
+                {
+                    context.Succeed(requirement);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Adding Authorization policy where the ApiKey from Authorization is added as claim to the Principal
Added ApiKeyRequirement
Added ApiKeyRequirementHandler for asserting the ApiKey claim

I wanted to use a policy for ApiKey authorization. The Authorization package should find the ApiKey on the Authorization HEADER and add the key as claim to the current principal identity.
An authorization policy should assert the ApiKey, using a Requirement and RequirementHandler. The Controller or Action is adorned with [Authorize(Policy="ApiKeyPolicy")]